### PR TITLE
fix(apps.py): added 'structured' in apps because needed in django admin

### DIFF
--- a/camomilla/theme/apps.py
+++ b/camomilla/theme/apps.py
@@ -34,4 +34,5 @@ class CamomillaThemeConfig(AppConfig):
             "django_jsonform",
             "admin_interface",
             "colorfield",
+            "structured",
         )


### PR DESCRIPTION
Added 'structured' in apps to avoid error in django admin when using StructuredJson fields (i.e. Menu detail page)