### PR TITLE
feat(templates): added template tag and accordion in base.html

### DIFF
--- a/camomilla/templates/defaults/base.html
+++ b/camomilla/templates/defaults/base.html
@@ -1,5 +1,7 @@
 {% load menus %}
 {% load i18n %}
+{% load model_extras %}
+
 {% get_current_language as current_lang %}
 
 
@@ -9,9 +11,6 @@
     <title>Camomilla CMS</title>
     <style>
         html,
-        body {
-            height: 100%;
-        }
 
         body {
             background-color: #f7fafc;
@@ -48,6 +47,45 @@
         .temp_type{
             font-size: 18px;
             font-style: italic;
+        }
+        .accordion {
+            margin: 2rem auto;
+            border: 1px solid #000;
+            font-family: monospace;
+            width: 800px;
+            max-width: 800px;
+        }
+
+        .accordion-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 1rem;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .accordion-icon {
+            width: 1rem;
+            height: 1rem;
+            transition: transform 0.3s ease;
+        }
+
+        .accordion-toggle:checked + .accordion-header .accordion-icon {
+            transform: rotate(180deg);
+        }
+
+        .accordion-body {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s ease;
+        }
+
+        .accordion-toggle:checked + .accordion-header + .accordion-body {
+            max-height: 30vh;
+            padding: 1rem;
+            border-top: 1px solid #000;
+            overflow-y: auto;
         }
     </style>
 </head>
@@ -104,11 +142,29 @@
         - <b>Module:</b> {{page_model.module}} <br>
         - <b>Identifier:</b> {{page.pk}} <br>
         - <b>Permalink:</b> {{page.permalink}} <br>
-        - <b>Language:</b> {{current_lang}} <br>        
+        - <b>Language:</b> {{current_lang}} <br>             
     </code>
+    
     {% endblock %}
+
     {% block content %}
     {% endblock %}
+    
+    <div class="accordion">
+    <input type="checkbox" id="accordion-toggle" class="accordion-toggle" hidden>
+    <label for="accordion-toggle" class="accordion-header">
+        <span>Page data</span>
+        <svg class="accordion-icon" viewBox="0 0 24 24">
+        <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        </svg>
+    </label>
+    <div class="accordion-body">
+        <pre>{{ page|to_pretty_dict|safe }}</pre>
+    </div>
+</div>
+
+</div>
+
 </body>
 
 </html>

--- a/camomilla/templatetags/model_extras.py
+++ b/camomilla/templatetags/model_extras.py
@@ -1,0 +1,71 @@
+from django import template
+from django.utils.safestring import mark_safe
+from django.forms.models import model_to_dict
+from structured.pydantic.models import BaseModel
+import json
+import re
+import html
+from datetime import datetime
+
+register = template.Library()
+
+def custom_json_serializer(obj):
+    """Serialize custom objects to JSON."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+def pretty_dict(data, indent_level=0):
+    """
+    Recursive function to format a dictionary into a pretty string.
+    Args:
+        data (dict): The dictionary to format.
+        indent_level (int): The current indentation level.
+    Returns:
+        str: A pretty-printed string representation of the dictionary.
+    """
+    indent = "  " * indent_level
+    result = []
+
+    for key, value in data.items():
+
+        if isinstance(value, dict):
+            result.append(f"{indent}'{key}': {{")
+            result.append(pretty_dict(value, indent_level + 1))
+            result.append(f"{indent}}},")
+
+        elif isinstance(value, list):
+            result.append(f"{indent}'{key}': [")
+            for item in value:
+                if isinstance(item, dict):
+                    result.append(pretty_dict(item, indent_level + 1))
+                else:
+                    result.append(f"{indent}  {json.dumps(item, default=custom_json_serializer)},")
+            result.append(f"{indent}],")
+
+        else:
+            result.append(f"{indent}'{key}': {json.dumps(value, default=custom_json_serializer)},")
+
+    return "\n".join(result).rstrip(',')
+
+@register.filter
+def to_pretty_dict(instance):
+    data = model_to_dict(instance)
+
+    for key, value in data.items():
+        if isinstance(value, BaseModel):
+            data[key] = value.model_dump()
+
+    formatted_dict = "{\n" + pretty_dict(data, indent_level=1) + "\n}"
+
+    escaped = html.escape(formatted_dict)
+
+    # This to highlight the keys in the JSON
+    highlighted = re.sub(
+        r"(&#x27;)([^&#]+?)(&#x27;):",
+        r"<span style='color:#df3079'>'\2'</span>:",
+        escaped
+    )
+
+    return mark_safe(f"<pre>{highlighted}</pre>")
+

--- a/camomilla/templatetags/model_extras.py
+++ b/camomilla/templatetags/model_extras.py
@@ -9,11 +9,13 @@ from datetime import datetime
 
 register = template.Library()
 
+
 def custom_json_serializer(obj):
     """Serialize custom objects to JSON."""
     if isinstance(obj, datetime):
         return obj.isoformat()
     raise TypeError(f"Type {type(obj)} not serializable")
+
 
 def pretty_dict(data, indent_level=0):
     """
@@ -48,6 +50,7 @@ def pretty_dict(data, indent_level=0):
 
     return "\n".join(result).rstrip(',')
 
+
 @register.filter
 def to_pretty_dict(instance):
     data = model_to_dict(instance)
@@ -68,4 +71,3 @@ def to_pretty_dict(instance):
     )
 
     return mark_safe(f"<pre>{highlighted}</pre>")
-


### PR DESCRIPTION
![Screenshot from 2025-05-14 12-15-36](https://github.com/user-attachments/assets/0de760d9-7193-4530-b6e4-a38766a6fcbc)
Added a `to_pretty_dict` template tag and an accordion element on `camomilla/templates/defaults/base.html` to display all the page data. 

`BaseModel` subclassed will be rendered as pretty dictionaries:

![Screenshot from 2025-05-14 12-20-23](https://github.com/user-attachments/assets/278d1f3a-5253-4ae4-89a7-589b592bf31a)
