### PR TITLE
fix(UserSerializer): add missing fields from Django User Model

### DIFF
--- a/camomilla/serializers/user.py
+++ b/camomilla/serializers/user.py
@@ -91,6 +91,10 @@ class UserSerializer(BaseModelSerializer):
             "user_permissions",
             "has_token",
             "is_superuser",
+            "is_staff",
+            "is_active",
+            "date_joined",
+            "last_login",
         )
 
     def validate_password(self, value):


### PR DESCRIPTION
Add "is_staff", "is_active", "date_joined", "last_login" to UserSerializer's fields